### PR TITLE
Add missing CKNULL after XMALLOC

### DIFF
--- a/libs/libscimp/src/SCimpProtocol.c
+++ b/libs/libscimp/src/SCimpProtocol.c
@@ -415,7 +415,7 @@ static SCLError sComputeSessionID(SCimpContext* ctx)
     
     len += (initStr?strlen(initStr):0) +1;
     len +=(respStr?strlen(respStr):0) +1;
-    p = sIDStr = XMALLOC(len);
+    p = sIDStr = XMALLOC(len); CKNULL(p);
     
     *p++ = initStr?strlen(initStr):0 ;
     if(initStr)

--- a/libs/shared/SCccm.c
+++ b/libs/shared/SCccm.c
@@ -92,6 +92,7 @@ SCLError CCM_Encrypt(uint8_t *key, size_t keyLen,
     
     buffLen = inLen + bytes2Pad;
     buffer = XMALLOC(buffLen);
+    CKNULL(buffer);
     
     memcpy(buffer, in, inLen);
     memset(buffer+inLen, bytes2Pad, bytes2Pad);
@@ -145,6 +146,7 @@ SCLError CCM_Decrypt(uint8_t *key,  size_t keyLen,
     unsigned long tagLen = sizeof(T);
     
     buffer = XMALLOC(buffLen);
+    CKNULL(buffer);
     
     status = ccm_memory(find_cipher("aes"), 
                         key, IVlen , 

--- a/libs/shared/SCgcm.c
+++ b/libs/shared/SCgcm.c
@@ -88,6 +88,7 @@ SCLError GCM_Encrypt(uint8_t *key, size_t keyLen,
     
     buffLen = inLen + bytes2Pad;
     buffer = XMALLOC(buffLen);
+    CKNULL(buffer);
     
     memcpy(buffer, in, inLen);
     memset(buffer+inLen, bytes2Pad, bytes2Pad);
@@ -141,6 +142,7 @@ SCLError GCM_Decrypt(uint8_t *key,  size_t keyLen,
     unsigned long tagLen = sizeof(T);
     
     buffer = XMALLOC(buffLen);
+    CKNULL(buffer);
     
     status = gcm_memory(find_cipher("aes"), 
                         key, IVlen , 

--- a/libs/shared/tomcryptwrappers.c
+++ b/libs/shared/tomcryptwrappers.c
@@ -914,6 +914,7 @@ SCLError MSG_Encrypt(uint8_t *key, size_t key_len,
     
     buffLen = in_len + bytes2Pad;
     buffer = XMALLOC(buffLen);
+    CKNULL(buffer);
     
     memcpy(buffer, in, in_len);
     memset(buffer+in_len, bytes2Pad, bytes2Pad);
@@ -975,6 +976,7 @@ SCLError MSG_Decrypt(uint8_t *key, size_t key_len,
     
     
     buffer = XMALLOC(buffLen);
+    CKNULL(buffer);
       
     err = CBC_Init(algorithm, key, iv,  &cbc);CKERR;
     

--- a/scripts/xmalloc-cknull.cocci
+++ b/scripts/xmalloc-cknull.cocci
@@ -1,0 +1,37 @@
+@xmalloc@
+identifier x;
+position p;
+@@
+  x = <+... XMALLOC@p(...) ...+>;
+
+@ok1@
+identifier xmalloc.x;
+position xmalloc.p;
+statement S;
+@@
+  x = <+... XMALLOC@p(...) ...+>;
+  ... when != x
+  if (x == NULL)
+    S
+
+@ok2@
+identifier xmalloc.x;
+position xmalloc.p;
+@@
+  x = <+... XMALLOC@p(...) ...+>;
+  ... when != x
+  CKNULL(x);
+
+@depends on !ok1 && !ok2@
+identifier xmalloc.x;
+position xmalloc.p;
+type T;
+statement S;
+@@
+  T err = ...;
+  ...
+  x = <+... XMALLOC@p(...) ...+>;
++ CKNULL(x);
+  ...
+  done:
+    S


### PR DESCRIPTION
I noticed a single line in SCimpProtocol.c where `CKNULL` was missing after an `XMALLOC`.

In this branch there is a [Coccinelle](http://coccinelle.lip6.fr/) semantic patch which found a couple other instances. The first rule matches any `XMALLOC` calls; the second and third match those which are followed by a `NULL` check; and the third matches any remaining and adds a `CKNULL`.
